### PR TITLE
fix: Correct fetch-depth to resolve patch creation error

### DIFF
--- a/.github/workflows/handle_sub2_patch.yml
+++ b/.github/workflows/handle_sub2_patch.yml
@@ -77,6 +77,7 @@ jobs:
           ref: main
           token: ${{ secrets.token }}
           path: sub2
+          fetch-depth: 0
 
       - name: Create and Commit Patch
         id: commit_patch


### PR DESCRIPTION
The `handle_sub2_patch.yml` workflow was failing with a `fatal: Invalid revision range` error during the `git format-patch` command.

This was caused by a shallow clone (`fetch-depth: 1`) which did not include the full commit history needed to generate the patch.

This commit changes the `fetch-depth` to `0` to perform a full clone, ensuring all necessary commits are present for the patch creation process.