### PR TITLE
fix(ci): Update deprecated set-output command in workflow

### DIFF
--- a/.github/workflows/handle_sub2_patch.yml
+++ b/.github/workflows/handle_sub2_patch.yml
@@ -104,7 +104,7 @@ jobs:
           if [ -z "$(git status --porcelain)" ]; then
             echo "No new patches created."
             CURRENT_SHA=$(git rev-parse HEAD)
-            echo "::set-output name=new_commit_sha::$CURRENT_SHA"
+            echo "new_commit_sha=$CURRENT_SHA" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -115,4 +115,4 @@ jobs:
 
           NEW_COMMIT_SHA=$(git rev-parse HEAD)
           echo "New commit SHA: $NEW_COMMIT_SHA"
-          echo "::set-output name=new_commit_sha::$NEW_COMMIT_SHA"
+          echo "new_commit_sha=$NEW_COMMIT_SHA" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This commit fixes an issue where the `handle_sub2_patch.yml` workflow would hang indefinitely.

The root cause was the use of the `::set-output` command, which has been deprecated by GitHub Actions and no longer functions on recent runners. This caused the step to fail to produce its expected output, which in turn caused the calling workflow to wait forever.

The fix replaces the deprecated `::set-output` commands with the new recommended syntax, which writes to the `$GITHUB_OUTPUT` environment file.