### PR TITLE
fix(ci): Add execute permission to patch script in workflow

### DIFF
--- a/.github/workflows/handle_sub2_patch.yml
+++ b/.github/workflows/handle_sub2_patch.yml
@@ -95,6 +95,9 @@ jobs:
           git fetch origin main
           git reset --hard origin/main
 
+          # Make the script executable
+          chmod +x ./bpdr_build/create_patches.sh
+
           # Run the script to create the patches
           # The script will read the git log and create patches in the 'patches' directory.
           ./bpdr_build/create_patches.sh


### PR DESCRIPTION
This commit fixes a "Permission denied" error in the `handle_sub2_patch.yml` workflow.

The `create_patches.sh` script was not executable in the GitHub Actions runner environment, causing the workflow to fail.

This fix adds a `chmod +x` command to the workflow to explicitly grant execute permissions to the script before it is run. This ensures the script can be executed reliably in the CI environment.