### PR TITLE
feat: Allow workflows to merge to any branch

### DIFF
--- a/.github/workflows/handle_sub2_patch.yml
+++ b/.github/workflows/handle_sub2_patch.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: tangophi/sub2
-          ref: main
+          ref: ${{ inputs.branch_name }}
           token: ${{ secrets.token }}
           path: sub2
           fetch-depth: 0
@@ -90,10 +90,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # The PR has been merged, so the main branch is updated.
-          # We need to be on the latest version of main.
-          git fetch origin main
-          git reset --hard origin/main
+          # The PR has been merged, so the branch is updated.
+          # We need to be on the latest version of the branch.
+          git fetch origin ${{ inputs.branch_name }}
+          git reset --hard origin/${{ inputs.branch_name }}
 
           # Make the script executable
           chmod +x ./bpdr_build/create_patches.sh
@@ -114,7 +114,7 @@ jobs:
           # Add, commit, and push the new patch files
           git add patches/*.patch
           git commit -m "Create patches for PR #${PR_NUMBER}"
-          git push origin main
+          git push origin ${{ inputs.branch_name }}
 
           NEW_COMMIT_SHA=$(git rev-parse HEAD)
           echo "New commit SHA: $NEW_COMMIT_SHA"

--- a/.github/workflows/merge_submodule_prs.yml
+++ b/.github/workflows/merge_submodule_prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   extract-prs:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: github.event.pull_request.merged == true
     outputs:
       sub1_prs: ${{ steps.extract.outputs.sub1_prs }}
       sub2_prs: ${{ steps.extract.outputs.sub2_prs }}
@@ -25,7 +25,7 @@ jobs:
           SUB2_PRS=$(echo "$PR_BODY" | grep -o "https://github.com/$OWNER/sub2/pull/[0-9]*" | awk -F'/' '{print $NF}' | jq -R . | jq -s -c .)
           echo "::set-output name=sub1_prs::$SUB1_PRS"
           echo "::set-output name=sub2_prs::$SUB2_PRS"
-          echo "::set-output name=branch::${{ github.event.pull_request.head.ref }}"
+          echo "::set-output name=branch::${{ github.event.pull_request.base.ref }}"
 
   merge-sub1-prs:
     needs: extract-prs
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout parent repository
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.base.ref }}
           token: ${{ secrets.MY_PAT }}
           submodules: 'recursive'
           submodule-fetch-depth: 0
@@ -77,11 +77,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          echo "Updating sub1 to the latest on main..."
-          (cd source/sub1 && git checkout main && git pull)
+          echo "Updating sub1 to the latest on ${{ github.event.pull_request.base.ref }}..."
+          (cd source/sub1 && git checkout ${{ github.event.pull_request.base.ref }} && git pull)
 
-          echo "Updating sub2 to the latest on main..."
-          (cd source/sub2 && git checkout main && git pull)
+          echo "Updating sub2 to the latest on ${{ github.event.pull_request.base.ref }}..."
+          (cd source/sub2 && git checkout ${{ github.event.pull_request.base.ref }} && git pull)
 
           # See if there are any changes to commit
           if git diff --quiet --exit-code; then
@@ -92,4 +92,4 @@ jobs:
           echo "Committing submodule updates..."
           git add source/sub1 source/sub2
           git commit -m "Update submodules to latest"
-          git push origin main
+          git push origin ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
Modified the GitHub workflows to remove hardcoded "main" branch references.

The workflows will now use the base branch of the pull request, allowing them to merge to any feature branch, not just main.

Changes made:
- In `merge_submodule_prs.yml`:
  - Removed the `main` branch restriction.
  - Updated to use the PR's base branch for checkout, submodule updates, and push.
- In `handle_sub2_patch.yml`:
  - Updated to use the `branch_name` input to work with any branch.